### PR TITLE
Ft user edit incident #162411166

### DIFF
--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -2,13 +2,14 @@ from flask import Blueprint
 from flask_restful import Api
 from .views import (SignUpEndpoint, LoginEndpoint,
                     RefreshTokenEndpoint,AllIncidentsEndpoint,
-                    IncidentEndpoint)
+                    IncidentEndpoint, IncidentEditCommentEndpoint)
 
 v2 = Blueprint('api', __name__, url_prefix='/api/v2')
 api = Api(v2)
 
 api.add_resource(SignUpEndpoint,'/signup')
 api.add_resource(LoginEndpoint,'/login')
-api.add_resource(IncidentEndpoint,'/incident/<int:incidentId>')
 api.add_resource(AllIncidentsEndpoint,'/incidents')
+api.add_resource(IncidentEndpoint,'/incident/<int:incidentId>')
+api.add_resource(IncidentEditCommentEndpoint,'/incident/<int:incidentId>/comment')
 api.add_resource(RefreshTokenEndpoint,'/token')

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -2,7 +2,8 @@ from flask import Blueprint
 from flask_restful import Api
 from .views import (SignUpEndpoint, LoginEndpoint,
                     RefreshTokenEndpoint,AllIncidentsEndpoint,
-                    IncidentEndpoint, IncidentEditCommentEndpoint)
+                    IncidentEndpoint, IncidentEditCommentEndpoint,
+                    IncidentEditLocationEndpoint)
 
 v2 = Blueprint('api', __name__, url_prefix='/api/v2')
 api = Api(v2)
@@ -12,4 +13,5 @@ api.add_resource(LoginEndpoint,'/login')
 api.add_resource(AllIncidentsEndpoint,'/incidents')
 api.add_resource(IncidentEndpoint,'/incident/<int:incidentId>')
 api.add_resource(IncidentEditCommentEndpoint,'/incident/<int:incidentId>/comment')
+api.add_resource(IncidentEditLocationEndpoint,'/incident/<int:incidentId>/location')
 api.add_resource(RefreshTokenEndpoint,'/token')

--- a/app/api/v2/models.py
+++ b/app/api/v2/models.py
@@ -115,3 +115,13 @@ class Incident():
         else:
             self.db.commit()
             return True
+
+    def edit_location(self, incidentId, location, createdBy):
+        try: 
+            self.curr.execute("UPDATE public.\"Incident\" SET location = %s WHERE createdBy = %s AND id = %s AND status = %s ;",
+            (location,createdBy,incidentId,'draft',))
+        except psycopg2.ProgrammingError:
+            return False
+        else:
+            self.db.commit()
+            return True

--- a/app/api/v2/models.py
+++ b/app/api/v2/models.py
@@ -86,7 +86,7 @@ class Incident():
         except psycopg2.ProgrammingError:
             return False
         else:
-            return self.curr.fetchall()
+            return self.curr.fetchone()
 
     def get_incidents(self,createdBy):
         try: 
@@ -97,4 +97,21 @@ class Incident():
         else:
             return self.curr.fetchall()
 
-    
+    def validate_edit(self,incidentId,createdBy):
+        try: 
+            self.curr.execute("SELECT * FROM public.\"Incident\" WHERE createdBy = %s AND id = %s AND status = %s ;",
+            (createdBy,incidentId,'draft'))
+        except psycopg2.ProgrammingError:
+            return False
+        else:
+            return self.curr.fetchone()
+
+    def edit_comment(self, incidentId, comment):
+        try: 
+            self.curr.execute("UPDATE public.\"Incident\" SET comment = %s  WHERE createdBy = %s AND id = %s AND status = %s ;",
+            (comment,incidentId,'draft'))
+        except psycopg2.ProgrammingError:
+            return False
+        else:
+            self.db.commit()
+            return True

--- a/app/api/v2/models.py
+++ b/app/api/v2/models.py
@@ -100,16 +100,16 @@ class Incident():
     def validate_edit(self,incidentId,createdBy):
         try: 
             self.curr.execute("SELECT * FROM public.\"Incident\" WHERE createdBy = %s AND id = %s AND status = %s ;",
-            (createdBy,incidentId,'draft'))
+            (createdBy,incidentId,"draft",))
         except psycopg2.ProgrammingError:
             return False
         else:
             return self.curr.fetchone()
 
-    def edit_comment(self, incidentId, comment):
+    def edit_comment(self, incidentId, comment, createdBy):
         try: 
-            self.curr.execute("UPDATE public.\"Incident\" SET comment = %s  WHERE createdBy = %s AND id = %s AND status = %s ;",
-            (comment,incidentId,'draft'))
+            self.curr.execute("UPDATE public.\"Incident\" SET comment = %s WHERE createdBy = %s AND id = %s AND status = %s ;",
+            (comment,createdBy,incidentId,'draft',))
         except psycopg2.ProgrammingError:
             return False
         else:

--- a/app/api/v2/views.py
+++ b/app/api/v2/views.py
@@ -206,11 +206,11 @@ class IncidentEditCommentEndpoint(BaseEndpoint):
 
         exists_owned = self.i.validate_edit(incidentId, createdBy)
 
-        if exists_owned is not None or exists_owned == False:
+        if exists_owned is None or exists_owned == False:
             return make_response(jsonify({
                 "message": "Forbidden: Record not owned/ Not in draft status"}), 403)
 
-        edit = self.i.edit_comment(incidentId, data['comment'])
+        edit = self.i.edit_comment(incidentId, data['comment'], createdBy)
         if edit == True:
             return make_response(jsonify({
                 'message': "Incident Updated",

--- a/app/api/v2/views.py
+++ b/app/api/v2/views.py
@@ -218,3 +218,39 @@ class IncidentEditCommentEndpoint(BaseEndpoint):
 
         return make_response(jsonify({
             "message": "Cannot update a record at the moment"}), 403)
+
+
+class IncidentEditLocationEndpoint(BaseEndpoint):
+    """
+    Enpoint PUT /incident/1
+    Allows for editing the location on an incident
+    """
+    @jwt_required
+    def put(self, incidentId):
+        """  Allows for editing the location on an incident"""
+
+        user = get_jwt_identity()
+        createdBy = self.u.get_user(user)['id']
+        data = request.get_json(force=True)
+        incident_data = IncidentEditSchema(
+            only=('location',)).load(data)
+        if incident_data.errors:
+            return make_response(jsonify({
+                "message": "location/userid is not present",
+                "required": incident_data.errors}),
+                400)
+
+        exists_owned = self.i.validate_edit(incidentId, createdBy)
+
+        if exists_owned is None or exists_owned == False:
+            return make_response(jsonify({
+                "message": "Forbidden: Record not owned/ Not in draft status"}), 403)
+
+        edit = self.i.edit_location(incidentId, data['location'], createdBy)
+        if edit == True:
+            return make_response(jsonify({
+                'message': "Incident Updated",
+            }), 200)
+
+        return make_response(jsonify({
+            "message": "Cannot update a record at the moment"}), 403)


### PR DESCRIPTION
#### What does this PR do?
It adds the edit location and comment feature for records that are in draft status and are owned by the user.
#### Description of Task to be completed?
Everytime a user seeks to edit a record, they should be only allowed to do so on draft and owned records
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162411166
#### Screenshots (if appropriate)
#### Questions:
